### PR TITLE
ci(newman): functional testing using postman/newman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
       - name: Run the API & test
         env:
           MONGO_URI: "mongodb://user:password@localhost/machinery?authSource=admin"
-        run: bash run_app & docker run -v "$(pwd)"/postman:/etc/postman --network host -t postman/newman run /etc/postman/Machinery.postman_collection.json -e /etc/postman/Machinery\ -\ Local.postman_env.json 
+        run: | 
+          bash run_app & 
+          docker run -v "$(pwd)"/postman:/etc/postman --network host -t postman/newman run /etc/postman/Machinery.postman_collection.json -e /etc/postman/Machinery\ -\ Local.postman_env.json 
 
   linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As we discussed into #13, implemented functional tests using `postman/newman` to the project CI.

Some explication on how this job has been built: 
- 1: Setup our `MongoDB` database
- 2: Setup Python & Docker
- 3: Install Python dependencies & pull `postman/newman` image
- 4: Run the application using the `run_app` script, then run our postman collection (bind-mounted to the image)

If you need any further information, let me know ! 

Based on what we discused on #13, I personnaly think that it would be a good idea to resolve #13 and open a new issue to plan on the "more robust and long term" solution. 


Closes #13 